### PR TITLE
fix the run-wp-commands.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
also add .gitattributes file to to enforce Unix-style line endings for .sh files